### PR TITLE
Fetch timestamps from changeset endpoint

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -384,7 +384,7 @@ mod tests {
                 "metadata": {},
                 "changes": [],
                 "timestamp": 0
-            }"#
+            }"#,
             r#"{
                 "metadata": {
                     "data": "test"

--- a/src/client.rs
+++ b/src/client.rs
@@ -67,7 +67,6 @@ pub struct ClientBuilder {
 }
 
 impl ClientBuilder {
-
     /// Constructs a new `ClientBuilder`.
     ///
     /// This is the same as `Client::builder()`.
@@ -76,7 +75,7 @@ impl ClientBuilder {
             server_url: DEFAULT_SERVER_URL.to_owned(),
             bucket_name: DEFAULT_BUCKET_NAME.to_owned(),
             collection_name: "".to_owned(),
-            verifier: Box::new(AlwaysAcceptsVerifier{}),
+            verifier: Box::new(AlwaysAcceptsVerifier {}),
         };
     }
 
@@ -110,7 +109,7 @@ impl ClientBuilder {
             server_url: self.server_url,
             bucket_name: self.bucket_name,
             collection_name: self.collection_name,
-            verifier: self.verifier
+            verifier: self.verifier,
         }
     }
 }
@@ -155,13 +154,12 @@ impl Default for Client {
             server_url: DEFAULT_SERVER_URL.to_owned(),
             bucket_name: DEFAULT_BUCKET_NAME.to_owned(),
             collection_name: "".to_owned(),
-            verifier: Box::new(AlwaysAcceptsVerifier{}),
+            verifier: Box::new(AlwaysAcceptsVerifier {}),
         };
     }
 }
 
 impl Client {
-
     /// Creates a `ClientBuilder` to configure a `Client`.
     ///
     /// This is the same as `ClientBuilder::new()`.
@@ -324,10 +322,10 @@ mod tests {
                 .build(),
             valid_latest_change_response,
             r#"{
-            "metadata": {},
-            "changes": [],
-            "timestamp": 0
-        }"#,
+                "metadata": {},
+                "changes": [],
+                "timestamp": 0
+            }"#,
             Err(ClientError::VerificationError {
                 name: "signature verification error".to_owned(),
             }),
@@ -342,15 +340,15 @@ mod tests {
                 .build(),
             valid_latest_change_response,
             r#"{
-            "metadata": {
-                "data": "test"
-            },
-            "changes": [{
-                "id": 1,
-                "last_modified": 100
-            }],
-            "timestamp": 0
-        }"#,
+                "metadata": {
+                    "data": "test"
+                },
+                "changes": [{
+                    "id": 1,
+                    "last_modified": 100
+                }],
+                "timestamp": 0
+            }"#,
             Ok(vec![json!({
                 "id": 1,
                 "last_modified": 100

--- a/src/client.rs
+++ b/src/client.rs
@@ -194,18 +194,21 @@ impl Client {
             &self.server_url,
             &self.bucket_name,
             &self.collection_name,
-            expected
-       )?;
+            Some(expected),
+        )?;
 
-       debug!("changeset.metadata {}", serde_json::to_string_pretty(&changeset.metadata)?);
+        debug!(
+            "changeset.metadata {}",
+            serde_json::to_string_pretty(&changeset.metadata)?
+        );
 
-       // verify the signature
-       let collection = Collection {
-           bid: self.bucket_name.to_owned(),
-           cid: self.collection_name.to_owned(),
-           metadata: changeset.metadata,
-           records: changeset.changes,
-           timestamp: changeset.timestamp
+        // verify the signature
+        let collection = Collection {
+            bid: self.bucket_name.to_owned(),
+            cid: self.collection_name.to_owned(),
+            metadata: changeset.metadata,
+            records: changeset.changes,
+            timestamp: changeset.timestamp,
         };
 
         self.verifier.verify(&collection)?;
@@ -264,9 +267,7 @@ mod tests {
     ) {
         let mut get_latest_change_mock = Mock::new()
             .expect_method(GET)
-            .expect_path("/buckets/monitor/collections/changes/records")
-            .expect_query_param("bucket", "main")
-            .expect_query_param("collection", "url-classifier-skip-urls")
+            .expect_path("/buckets/monitor/collections/changes/changeset")
             .return_status(200)
             .return_header("Content-Type", "application/json")
             .return_body(latest_change_response)
@@ -300,16 +301,18 @@ mod tests {
         let valid_latest_change_response = &format!(
             "{}",
             r#"{
-            "data": [
-                {
-                    "id": "123",
-                    "last_modified": 9173,
-                    "bucket":"main",
-                    "collection":"url-classifier-skip-urls",
-                    "host":"localhost:5000"
-                }
-            ]
-        }"#
+                "metadata": {},
+                "changes": [
+                    {
+                        "id": "123",
+                        "last_modified": 9173,
+                        "bucket":"main",
+                        "collection":"url-classifier-skip-urls",
+                        "host":"localhost:5000"
+                    }
+                ],
+                "timestamp": 0
+            }"#
         );
 
         test_get(
@@ -363,30 +366,43 @@ mod tests {
                 .build(),
             valid_latest_change_response,
             r#"{
-            "metadata": {},
-            "changes": [],
-            "timestamp": 0
-        }"#,
+                "metadata": {},
+                "changes": [],
+                "timestamp": 0
+            }"#,
             Err(ClientError::Error {
                 name: "invalid signature error".to_owned(),
             }),
         );
 
-        test_get(&mock_server,Client::builder()
-            .server_url(&mock_server_address)
-            .collection_name("url-classifier-skip-urls")
-            .verifier(Box::new(VerifierWithNoError {}))
-            .build(), &format!(
-            "{}",
+        test_get(
+            &mock_server,
+            Client::builder()
+                .server_url(&mock_server_address)
+                .collection_name("url-classifier-skip-urls")
+                .verifier(Box::new(VerifierWithNoError {}))
+                .build(),
+            &format!(
+                "{}",
+                r#"{
+                    "metadata": {},
+                    "changes": [],
+                    "timestamp": 0
+                }"#
+            ),
             r#"{
-            "data": []
-        }"#
-        ), r#"{
-            "metadata": {
-                "data": "test"
-            },
-            "changes": [],
-            "timestamp": 0
-        }"#, Err(ClientError::Error { name: format!("Unknown collection {}/{}", "main", "url-classifier-skip-urls") }));
+                "metadata": {
+                    "data": "test"
+                },
+                "changes": [],
+                "timestamp": 0
+            }"#,
+            Err(ClientError::Error {
+                name: format!(
+                    "Unknown collection {}/{}",
+                    "main", "url-classifier-skip-urls"
+                ),
+            }),
+        );
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -380,14 +380,11 @@ mod tests {
                 .collection_name("url-classifier-skip-urls")
                 .verifier(Box::new(VerifierWithNoError {}))
                 .build(),
-            &format!(
-                "{}",
-                r#"{
-                    "metadata": {},
-                    "changes": [],
-                    "timestamp": 0
-                }"#
-            ),
+            r#"{
+                "metadata": {},
+                "changes": [],
+                "timestamp": 0
+            }"#
             r#"{
                 "metadata": {
                     "data": "test"

--- a/src/client/kinto_http.rs
+++ b/src/client/kinto_http.rs
@@ -97,16 +97,13 @@ pub fn get_changeset(
         "The expected timestamp for bucket={}, collection={} is {:?}",
         bid, cid, expected
     );
-    let url = format!(
-        "{}/buckets/{}/collections/{}/changeset{}",
-        server,
-        bid,
-        cid,
-        match expected {
-            None => String::new(),
-            Some(v) => format!("?_expected={}", v),
+    let url = {
+        let mut partial = format!("{}/buckets/{}/collections/{}/changeset", server, bid, cid);
+        if let Some(v) = expected {
+            partial.push_str(&format!("?_expected={}", v));
         }
-    );
+        partial
+    };
     info!("Fetch {}...", url);
 
     let resp = Request::get(Url::parse(&url)?).send()?;

--- a/src/client/signatures.rs
+++ b/src/client/signatures.rs
@@ -4,8 +4,8 @@
 
 use crate::client::Collection;
 use base64;
-use url::{ParseError};
-use viaduct::{Error as ViaductError};
+use url::ParseError;
+use viaduct::Error as ViaductError;
 #[cfg(not(feature = "openssl_verifier"))]
 pub mod default_verifier;
 #[cfg(feature = "openssl_verifier")]


### PR DESCRIPTION
Basically, fetching from the `/changeset` endpoint will eventually give us gzip compression and consistency with JS client (See https://bugzilla.mozilla.org/show_bug.cgi?id=1666511)