### PR TITLE
Gate doctests on the features they depend on.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -271,10 +271,10 @@ impl ClientBuilder {
 ///
 /// With the `ring_verifier` feature, a signature verifier leveraging the [`ring` crate](https://crates.io/crates/ring).
 /// ```rust
+/// # #[cfg(feature = "ring_verifier")] {
 /// # use remote_settings_client::Client;
 /// use remote_settings_client::RingVerifier;
 ///
-/// # fn main() {
 /// let client = Client::builder()
 ///   .collection_name("cid")
 ///   .verifier(Box::new(RingVerifier {}))
@@ -286,10 +286,10 @@ impl ClientBuilder {
 ///
 /// With the `rc_crypto` feature, a signature verifier leveraging the [`rc_crypto` crate](https://github.com/mozilla/application-services/tree/v73.0.2/components/support/rc_crypto).
 /// ```rust
+/// # #[cfg(feature = "rc_crypto_verifier")] {
 /// # use remote_settings_client::Client;
 /// use remote_settings_client::RcCryptoVerifier;
 ///
-/// # fn main() {
 /// let client = Client::builder()
 ///   .collection_name("cid")
 ///   .verifier(Box::new(RcCryptoVerifier {}))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 //! ## Example
 //!
 //! ```rust
+//! # #[cfg(feature = "ring_verifier")] {
 //!   use remote_settings_client::{Client, RingVerifier};
 //!   use viaduct::set_backend;
 //!   use viaduct_reqwest::ReqwestBackend;
@@ -27,6 +28,7 @@
 //!     Ok(records) => println!("{:?}", records),
 //!     Err(error) => println!("Error fetching/verifying records: {:?}", error),
 //!   };
+//! # }
 //! ```
 //!
 //! See [`Client`] for more infos.


### PR DESCRIPTION
This makes `cargo test` without any features enabled pass. This isn't tested in CI, and it's probably not important enough to test it in CI either. The only reason I'm fixing it is that this broke rust-analyzer's feature to run individual tests.