### PR TITLE
Fix panic in check_sync_state()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ rc_crypto_verifier = ["x509-parser", "rc_crypto"]
 env_logger = "0.8.3"
 httpmock = "0.5.6"
 viaduct-reqwest = { git = "https://github.com/mozilla/application-services", rev = "v74.0.1"}
+mock_instant = "0.2.1"
 
 [dependencies]
 base64 = "0.13.0"

--- a/src/client.rs
+++ b/src/client.rs
@@ -453,6 +453,7 @@ mod tests {
         // Assert defaults for consumers.
         assert!(
             client.server_url.contains("services.mozilla.com"),
+            "Unexpected server URL: {}",
             client.server_url
         );
         assert_eq!(client.bucket_name, "main");

--- a/src/client/kinto_http.rs
+++ b/src/client/kinto_http.rs
@@ -367,8 +367,10 @@ mod tests {
 
         let mut redirects_mock = mock_server.mock(|when, then| {
             when.path("/buckets/monitor/collections/changes/changeset");
-            then.status(302)
-                .header("Location", "/v2/buckets/monitor/collections/changes/changeset");
+            then.status(302).header(
+                "Location",
+                "/v2/buckets/monitor/collections/changes/changeset",
+            );
         });
 
         let mut changeset_mock = mock_server.mock(|when, then| {
@@ -389,9 +391,7 @@ mod tests {
             );
         });
 
-        let res =
-            get_latest_change_timestamp(&mock_server.url(""), "main", "crlite")
-                .unwrap();
+        let res = get_latest_change_timestamp(&mock_server.url(""), "main", "crlite").unwrap();
 
         assert_eq!(res, 5678);
 

--- a/src/client/kinto_http.rs
+++ b/src/client/kinto_http.rs
@@ -271,7 +271,7 @@ mod tests {
                     "changeset timestamp could not be parsed: \"foo\""
                 )
             }
-            e => assert!(false, format!("Unexpected error type: {:?}", e)),
+            e => assert!(false, "Unexpected error type: {:?}", e),
         };
 
         get_latest_change_mock.delete();
@@ -312,7 +312,7 @@ mod tests {
                 let details = info.details.as_ref().unwrap();
                 assert_eq!(details["field"].as_str().unwrap(), "_expected");
             }
-            e => assert!(false, format!("Unexpected error type: {:?}", e)),
+            e => assert!(false, "Unexpected error type: {:?}", e),
         };
 
         get_changeset_mock.delete();
@@ -353,7 +353,7 @@ mod tests {
                 assert_eq!(info.error, "Service unavailable");
                 assert_eq!(info.details, None);
             }
-            e => assert!(false, format!("Unexpected error type: {:?}", e)),
+            e => assert!(false, "Unexpected error type: {:?}", e),
         };
 
         get_changeset_mock.delete();

--- a/src/client/signatures.rs
+++ b/src/client/signatures.rs
@@ -180,7 +180,7 @@ mod tests {
         let err = verifier.fetch_certificate_chain(&collection).unwrap_err();
         match err {
             SignatureError::MissingSignatureField() => assert!(true),
-            e => assert!(false, format!("Unexpected error type: {:?}", e)),
+            e => assert!(false, "Unexpected error type: {:?}", e),
         };
     }
 
@@ -218,7 +218,7 @@ mod tests {
                 timestamp: 0,
             };
             let err = verifier.fetch_certificate_chain(&collection).unwrap_err();
-            assert!(err.to_string().contains(error), err.to_string());
+            assert!(err.to_string().contains(error), "{}", err.to_string());
         }
 
         pem_mock.delete();


### PR DESCRIPTION
I noticed that I made an oversight in one of the last code reviews. The difference between two `Instant`'s is unsigned, and it will panic when you subtract the later one from the earlier one.

To add a test for this, I needed to mock `std::time::Instant`, and I added a new dev dependency for this.

I also fixed a new compiler warning. (Additionally, there's a new clippy lint about the case of acronyms like `HTTPBackendError` which I decided not to fix – up to you whether you prefer to fix that or disable the lint.)