### PR TITLE
Add an abstraction around the HTTP client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,10 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-default = []
+default = ["viaduct_client"]
 ring_verifier = ["oid-registry", "ring"]
 rc_crypto_verifier = ["rc_crypto"]
+viaduct_client = ["viaduct"]
 
 [dev-dependencies]
 env_logger = "0.9.0"
@@ -24,7 +25,7 @@ hex = "0.4"
 log = "0.4.0"
 url = "2.1"
 # specifying viaduct dependency from git repo since viaduct is not published yet to crates.io
-viaduct = { git = "https://github.com/mozilla/application-services", rev = "v86.2.0"}
+viaduct = { git = "https://github.com/mozilla/application-services", rev = "v86.2.0", optional = true}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 derive_builder = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-default = ["viaduct_client"]
+default = []
 ring_verifier = ["oid-registry", "ring"]
 rc_crypto_verifier = ["rc_crypto"]
 viaduct_client = ["viaduct"]
@@ -17,6 +17,12 @@ env_logger = "0.9.0"
 httpmock = "0.6.2"
 viaduct-reqwest = { git = "https://github.com/mozilla/application-services", rev = "v86.2.0"}
 mock_instant = "0.2.1"
+# The following line is a workaround suggested on the rust-lang/cargo issue 2911
+# https://github.com/rust-lang/cargo/issues/2911#issuecomment-749580481 to make
+# it possible to enable features for tests. We need to enable the "viaduct_client"
+# feature for the tests because most of the tests use a mocked HTTP server and it
+# would be a non-trivial task to migrate them to use a fake client.
+remote-settings-client = { path = ".", features = ["viaduct_client"] }
 
 [dependencies]
 base64 = "0.13.0"

--- a/rs-client-demo/Cargo.toml
+++ b/rs-client-demo/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-remote-settings-client = {path = "../", features = ["ring_verifier"]}
+remote-settings-client = {path = "../", features = ["ring_verifier", "viaduct_client"]}
 log = "0.4.0"
 env_logger = "0.7.1"
 serde_json = "1.0"

--- a/rs-client-demo/src/main.rs
+++ b/rs-client-demo/src/main.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use remote_settings_client::client::{FileStorage, RingVerifier};
+use remote_settings_client::client::net::ViaductClient;
 use remote_settings_client::Client;
 use serde::Deserialize;
 pub use url::{ParseError, Url};
@@ -27,6 +28,7 @@ fn main() {
     print!("Fetching records using RS client with default Verifier: ");
 
     let mut client = Client::builder()
+        .http_client(Box::new(ViaductClient))
         .collection_name("url-classifier-skip-urls")
         .build()
         .unwrap();
@@ -59,12 +61,14 @@ fn main() {
             _ => "remote-settings",
         };
 
+        let mut temp_dir = std::env::temp_dir();
         let mut client = Client::builder()
+            .http_client(Box::new(ViaductClient))
             .bucket_name(&collection.bucket)
             .collection_name(&collection.collection)
             .signer_name(format!("{}.content-signature.mozilla.org", signer_name))
             .storage(Box::new(FileStorage {
-                folder: "/tmp".into(),
+                folder: temp_dir.into(),
                 ..FileStorage::default()
             }))
             .verifier(Box::new(RingVerifier {}))

--- a/src/client.rs
+++ b/src/client.rs
@@ -1152,8 +1152,7 @@ mod tests {
                 request_url: format!(
                     "{}/buckets/main/collections/nimbus/changeset?_expected={}",
                     fake_server, expected
-                )
-                .to_string(),
+                ),
                 response_status: 200,
                 response_body: json!(
                     {

--- a/src/client.rs
+++ b/src/client.rs
@@ -516,7 +516,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(not(feature = "viaduct_client"), ignore)]
     fn test_get_works_with_dummy_storage() {
         init();
 
@@ -582,7 +581,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(not(feature = "viaduct_client"), ignore)]
     fn test_get_with_empty_storage() {
         init();
 
@@ -648,7 +646,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(not(feature = "viaduct_client"), ignore)]
     fn test_get_empty_storage_no_sync_if_empty() {
         init();
         let mock_server = MockServer::start();
@@ -670,7 +667,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(not(feature = "viaduct_client"), ignore)]
     fn test_get_bad_stored_data() {
         init();
         let mock_server = MockServer::start();
@@ -694,7 +690,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(not(feature = "viaduct_client"), ignore)]
     fn test_get_bad_stored_data_if_untrusted() {
         init();
         let mock_server = MockServer::start();
@@ -732,7 +727,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(not(feature = "viaduct_client"), ignore)]
     fn test_get_with_empty_records_list() {
         init();
 
@@ -766,7 +760,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(not(feature = "viaduct_client"), ignore)]
     fn test_get_return_previously_synced_records() {
         init();
 
@@ -807,7 +800,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(not(feature = "viaduct_client"), ignore)]
     fn test_sync_pulls_current_timestamp_from_changes_endpoint_if_none() {
         init();
 
@@ -860,7 +852,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(not(feature = "viaduct_client"), ignore)]
     fn test_sync_uses_specified_expected_parameter() {
         init();
 
@@ -895,7 +886,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(not(feature = "viaduct_client"), ignore)]
     fn test_sync_fails_with_unknown_collection() {
         init();
 
@@ -935,7 +925,6 @@ mod tests {
 
     #[test]
     #[cfg(feature = "ring_verifier")]
-    #[cfg_attr(not(feature = "viaduct_client"), ignore)]
     fn test_sync_uses_x5u_from_metadata_to_verify_signatures() {
         init();
 
@@ -978,7 +967,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(not(feature = "viaduct_client"), ignore)]
     fn test_sync_wraps_signature_errors() {
         init();
 
@@ -1018,7 +1006,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(not(feature = "viaduct_client"), ignore)]
     fn test_sync_returns_collection_with_merged_changes() {
         init();
 
@@ -1144,7 +1131,7 @@ mod tests {
         let mut response_headers = Headers::new();
         response_headers.insert("backoff".to_string(), "300".to_string());
 
-        let fake_server = "https://www.example.com";
+        let fake_server = "https://www.example.com/v1";
 
         let test_responses: Vec<_> = [777, 888]
             .iter()
@@ -1172,7 +1159,7 @@ mod tests {
             .collect();
 
         let test_client: Box<dyn Requester + 'static> =
-            Box::new(TestHttpClient::new(false, test_responses));
+            Box::new(TestHttpClient::new(test_responses));
 
         let mut client = Client::builder()
             .server_url(fake_server)

--- a/src/client/kinto_http.rs
+++ b/src/client/kinto_http.rs
@@ -169,6 +169,7 @@ pub fn get_changeset(
 #[cfg(test)]
 mod tests {
     use super::{get_changeset, get_latest_change_timestamp, KintoError};
+    use httpmock::MockServer;
     use crate::client::net::{Headers, Requester, TestHttpClient, TestResponse};
 
     fn init() {
@@ -414,7 +415,6 @@ mod tests {
         };
     }
 
-    /* // TODO: This should really be in the HTTP tests
     #[test]
     fn test_fetch_follows_redirects() {
         init();
@@ -447,7 +447,9 @@ mod tests {
             );
         });
 
-        let res = get_latest_change_timestamp(&mock_server.url(""), "main", "crlite").unwrap();
+        let _ = viaduct::set_backend(&viaduct_reqwest::ReqwestBackend);
+        let viaduct_client: Box<dyn Requester + 'static> = Box::new(crate::client::net::ViaductClient);
+        let res = get_latest_change_timestamp(&viaduct_client, &mock_server.url(""), "main", "crlite").unwrap();
 
         assert_eq!(res, 5678);
 
@@ -456,5 +458,5 @@ mod tests {
 
         redirects_mock.delete();
         changeset_mock.delete();
-    }*/
+    }
 }

--- a/src/client/kinto_http.rs
+++ b/src/client/kinto_http.rs
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use crate::client::{net::Requester, net::Response};
 use log::{debug, info};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use url::{ParseError as URLParseError, Url};
-use viaduct::{Error as ViaductError, Request, Response};
 
 pub type KintoObject = serde_json::Value;
 
@@ -34,16 +34,18 @@ pub struct ErrorResponse {
 
 #[derive(Debug, Error)]
 pub enum KintoError {
-    #[error("a server error occured on {} {}: {}", response.request_method, response.url, info)]
+    #[error("a server error occured on GET {}: {}", url, info)]
     ServerError {
+        url: String,
         response: Response,
         info: ErrorResponse,
         retry_after: Option<u64>,
     },
-    #[error("the server responded with unexpected content on {} {}: HTTP {}", response.request_method, response.url, response.status)]
-    UnexpectedResponse { response: Response },
-    #[error("invalid request on {} {}: {}", response.request_method, response.url, info)]
+    #[error("the server responded with unexpected content on GET {}: HTTP {}", url, response.status)]
+    UnexpectedResponse { url: String, response: Response },
+    #[error("invalid request on GET {}: {}", url, info)]
     ClientRequestError {
+        url: String,
         response: Response,
         info: ErrorResponse,
     },
@@ -53,8 +55,8 @@ pub enum KintoError {
     InvalidChangesetBody(#[from] serde_json::Error),
     #[error("unknown collection: {bucket}/{collection}")]
     UnknownCollection { bucket: String, collection: String },
-    #[error("HTTP backend issue: {0}")]
-    HTTPBackendError(#[from] ViaductError),
+    #[error("HTTP backend issue")]
+    HTTPBackendError(),
     #[error("bad URL format: {0}")]
     URLError(#[from] URLParseError),
 }
@@ -71,11 +73,16 @@ impl std::fmt::Display for ErrorResponse {
     }
 }
 
-pub fn get_latest_change_timestamp(server: &str, bid: &str, cid: &str) -> Result<u64> {
+pub fn get_latest_change_timestamp(
+    requester: &Box<dyn Requester + 'static>,
+    server: &str,
+    bid: &str,
+    cid: &str,
+) -> Result<u64> {
     // When we fetch the monitor/changes endpoint manually (ie. not from a push notification)
     // we cannot know the current timestamp, and use 0 arbitrarily.
     let expected = 0;
-    let response = get_changeset(server, "monitor", "changes", expected, None)?;
+    let response = get_changeset(requester, server, "monitor", "changes", expected, None)?;
     let change = response
         .changes
         .iter()
@@ -96,6 +103,7 @@ pub fn get_latest_change_timestamp(server: &str, bid: &str, cid: &str) -> Result
 
 /// Fetches the collection content from the server.
 pub fn get_changeset(
+    requester: &Box<dyn Requester + 'static>,
     server: &str,
     bid: &str,
     cid: &str,
@@ -108,28 +116,35 @@ pub fn get_changeset(
         server, bid, cid, expected, since_param
     );
     info!("Fetch {}...", url);
-    let response = Request::get(Url::parse(&url)?).send()?;
+    let response = requester
+        .get(Url::parse(&url)?)
+        .map_err(|_err| KintoError::HTTPBackendError())?;
 
     if !response.is_success() {
         // Try to parse the server error response into JSON.
         // See https://docs.kinto-storage.org/en/stable/api/1.x/errors.html#error-responses
-        let info: ErrorResponse = match response.json() {
+        let info: ErrorResponse = match serde_json::from_slice(&response.body) {
             Ok(v) => v,
-            Err(_) => return Err(KintoError::UnexpectedResponse { response }),
+            Err(_) => return Err(KintoError::UnexpectedResponse { url, response }),
         };
 
         // Error due to the client. The request must be modified.
-        if response.is_client_error() {
-            return Err(KintoError::ClientRequestError { response, info });
+        if (400..500).contains(&response.status) {
+            return Err(KintoError::ClientRequestError {
+                url,
+                response,
+                info,
+            });
         }
 
-        if response.is_server_error() {
+        if (500..600).contains(&response.status) {
             let retry_after = response
                 .headers
                 .get("retry-after")
                 .map_or_else(|| None, |v| v.parse::<u64>().ok());
 
             return Err(KintoError::ServerError {
+                url,
                 response,
                 info,
                 retry_after,
@@ -143,7 +158,7 @@ pub fn get_changeset(
         .map_or_else(|| -1, |v| v.parse().unwrap_or(-1));
 
     debug!("Download {:?} bytes...", size);
-    let mut changeset: ChangesetResponse = response.json()?;
+    let mut changeset: ChangesetResponse = serde_json::from_slice(&response.body)?;
 
     // Check if server is indicating to clients to back-off.
     changeset.backoff = response.headers.get("backoff").and_then(|v| v.parse().ok());
@@ -154,26 +169,24 @@ pub fn get_changeset(
 #[cfg(test)]
 mod tests {
     use super::{get_changeset, get_latest_change_timestamp, KintoError};
-    use httpmock::MockServer;
-    use viaduct::set_backend;
-    use viaduct_reqwest::ReqwestBackend;
+    use crate::client::net::{Headers, Requester, TestHttpClient, TestResponse};
 
     fn init() {
         let _ = env_logger::builder().is_test(true).try_init();
-        let _ = set_backend(&ReqwestBackend);
     }
 
     #[test]
     fn test_fetch() {
         init();
 
-        let mock_server = MockServer::start();
-        let mock_server_address = mock_server.url("");
-
-        let mut get_latest_change_mock = mock_server.mock(|when, then| {
-            when.path("/buckets/monitor/collections/changes/changeset");
-            then.body(
-                r#"{
+        let test_client: Box<dyn Requester + 'static> = Box::new(TestHttpClient::new(
+            false,
+            vec![TestResponse {
+                request_url:
+                    "https://example.com/buckets/monitor/collections/changes/changeset?_expected=0"
+                        .to_string(),
+                response_status: 200,
+                response_body: r#"{
                     "metadata": {},
                     "changes": [
                         {
@@ -185,25 +198,41 @@ mod tests {
                         }
                     ],
                     "timestamp": 42
-                }"#,
-            );
-        });
+                }"#
+                .as_bytes()
+                .to_vec(),
+                response_headers: Headers::new(),
+            }],
+        ));
 
-        let res =
-            get_latest_change_timestamp(&mock_server_address, "main", "url-classifier-skip-urls")
-                .unwrap();
+        let res = get_latest_change_timestamp(
+            &test_client,
+            "https://example.com",
+            "main",
+            "url-classifier-skip-urls",
+        )
+        .unwrap();
 
         assert_eq!(res, 9173);
-
-        get_latest_change_mock.delete();
     }
 
     #[test]
     fn test_bad_url() {
         init();
 
+        let test_client: Box<dyn Requester + 'static> = Box::new(TestHttpClient::new(
+            true,
+            vec![TestResponse {
+                request_url: "%^".to_string(),
+                response_status: 500,
+                response_body: vec![],
+                response_headers: Headers::new(),
+            }],
+        ));
+
         let err =
-            get_latest_change_timestamp("%^", "main", "url-classifier-skip-urls").unwrap_err();
+            get_latest_change_timestamp(&test_client, "%^", "main", "url-classifier-skip-urls")
+                .unwrap_err();
         assert_eq!(
             err.to_string(),
             "bad URL format: relative URL without a base"
@@ -214,37 +243,44 @@ mod tests {
     fn test_bad_json() {
         init();
 
-        let mock_server = MockServer::start();
-        let mock_server_address = mock_server.url("");
-
-        let mut get_latest_change_mock = mock_server.mock(|when, then| {
-            when.path("/buckets/monitor/collections/changes/changeset");
-            then.body(
-                r#"{
+        let test_client: Box<dyn Requester + 'static> = Box::new(TestHttpClient::new(
+            false,
+            vec![TestResponse {
+                request_url:
+                    "https://example.com/buckets/monitor/collections/changes/changeset?_expected=0"
+                        .to_string(),
+                response_status: 200,
+                response_body: r#"{
                     "met :
-                }"#,
-            );
-        });
+                }"#
+                .as_bytes()
+                .to_vec(),
+                response_headers: Headers::new(),
+            }],
+        ));
 
-        let err =
-            get_latest_change_timestamp(&mock_server_address, "main", "url-classifier-skip-urls")
-                .unwrap_err();
+        let err = get_latest_change_timestamp(
+            &test_client,
+            "https://example.com",
+            "main",
+            "url-classifier-skip-urls",
+        )
+        .unwrap_err();
         assert_eq!(err.to_string(), "changeset content could not be parsed: control character (\\u0000-\\u001F) found while parsing a string at line 3 column 0");
-
-        get_latest_change_mock.delete();
     }
 
     #[test]
     fn test_bad_timestamp() {
         init();
 
-        let mock_server = MockServer::start();
-        let mock_server_address = mock_server.url("");
-
-        let mut get_latest_change_mock = mock_server.mock(|when, then| {
-            when.path("/buckets/monitor/collections/changes/changeset");
-            then.body(
-                r#"{
+        let test_client: Box<dyn Requester + 'static> = Box::new(TestHttpClient::new(
+            false,
+            vec![TestResponse {
+                request_url:
+                    "https://example.com/buckets/monitor/collections/changes/changeset?_expected=0"
+                        .to_string(),
+                response_status: 200,
+                response_body: r#"{
                     "metadata": {},
                     "changes": [
                         {
@@ -256,13 +292,20 @@ mod tests {
                         }
                     ],
                     "timestamp": 42
-                }"#,
-            );
-        });
+                }"#
+                .as_bytes()
+                .to_vec(),
+                response_headers: Headers::new(),
+            }],
+        ));
 
-        let err =
-            get_latest_change_timestamp(&mock_server_address, "main", "url-classifier-skip-urls")
-                .unwrap_err();
+        let err = get_latest_change_timestamp(
+            &test_client,
+            "https://example.com",
+            "main",
+            "url-classifier-skip-urls",
+        )
+        .unwrap_err();
 
         match err {
             KintoError::InvalidChangesetTimestamp(_) => {
@@ -273,22 +316,20 @@ mod tests {
             }
             e => panic!("Unexpected error type: {:?}", e),
         };
-
-        get_latest_change_mock.delete();
     }
 
     #[test]
     fn test_client_error_response() {
         init();
 
-        let mock_server = MockServer::start();
-        let mock_server_address = mock_server.url("");
-
-        let mut get_changeset_mock = mock_server.mock(|when, then| {
-            when.path("/buckets/main/collections/cfr/changeset")
-                .query_param("_expected", "451");
-            then.status(400).body(
-                r#"{
+        let test_client: Box<dyn Requester + 'static> = Box::new(TestHttpClient::new(
+            false,
+            vec![TestResponse {
+                request_url:
+                    "https://example.com/buckets/main/collections/cfr/changeset?_expected=451"
+                        .to_string(),
+                response_status: 400,
+                response_body: r#"{
                     "code": 400,
                     "error": "Bad request",
                     "errno": 123,
@@ -297,15 +338,26 @@ mod tests {
                         "field": "_expected",
                         "location": "querystring"
                     }
-                }"#,
-            );
-        });
+                }"#
+                .as_bytes()
+                .to_vec(),
+                response_headers: Headers::new(),
+            }],
+        ));
 
-        let err = get_changeset(&mock_server_address, "main", "cfr", 451, None).unwrap_err();
+        let err = get_changeset(
+            &test_client,
+            "https://example.com",
+            "main",
+            "cfr",
+            451,
+            None,
+        )
+        .unwrap_err();
 
         match err {
             KintoError::ClientRequestError { ref info, .. } => {
-                assert_eq!(err.to_string(), format!("invalid request on GET {}/buckets/main/collections/cfr/changeset?_expected=451: HTTP 400 Bad request: Bad value \'0\' for \'_expected\' (#123)", mock_server.base_url()));
+                assert_eq!(err.to_string(), "invalid request on GET https://example.com/buckets/main/collections/cfr/changeset?_expected=451: HTTP 400 Bad request: Bad value \'0\' for \'_expected\' (#123)");
                 assert_eq!(info.errno, 123);
                 assert_eq!(info.code, 400);
                 assert_eq!(info.error, "Bad request");
@@ -314,31 +366,36 @@ mod tests {
             }
             e => panic!("Unexpected error type: {:?}", e),
         };
-
-        get_changeset_mock.delete();
     }
 
     #[test]
     fn test_server_error_response() {
         init();
 
-        let mock_server = MockServer::start();
-        let mock_server_address = mock_server.url("");
+        let mut response_headers = Headers::new();
+        response_headers.insert("retry-after".to_string(), "360".to_string());
 
-        let mut get_changeset_mock = mock_server.mock(|when, then| {
-            when.path("/buckets/main/collections/cfr/changeset")
-                .query_param("_expected", "42");
-            then.status(503).header("Retry-After", "360").body(
-                r#"{
+        let test_client: Box<dyn Requester + 'static> = Box::new(TestHttpClient::new(
+            false,
+            vec![TestResponse {
+                request_url:
+                    "https://example.com/buckets/main/collections/cfr/changeset?_expected=42"
+                        .to_string(),
+                response_status: 503,
+                response_body: r#"{
                     "code": 503,
                     "error": "Service unavailable",
                     "errno": 999,
                     "message": "Boom"
-                }"#,
-            );
-        });
+                }"#
+                .as_bytes()
+                .to_vec(),
+                response_headers,
+            }],
+        ));
 
-        let err = get_changeset(&mock_server_address, "main", "cfr", 42, None).unwrap_err();
+        let err = get_changeset(&test_client, "https://example.com", "main", "cfr", 42, None)
+            .unwrap_err();
 
         match err {
             KintoError::ServerError {
@@ -346,7 +403,7 @@ mod tests {
                 ref info,
                 ..
             } => {
-                assert_eq!(err.to_string(), format!("a server error occured on GET {}/buckets/main/collections/cfr/changeset?_expected=42: HTTP 503 Service unavailable: Boom (#999)", mock_server.base_url()));
+                assert_eq!(err.to_string(), "a server error occured on GET https://example.com/buckets/main/collections/cfr/changeset?_expected=42: HTTP 503 Service unavailable: Boom (#999)");
                 assert_eq!(retry_after, Some(360));
                 assert_eq!(info.errno, 999);
                 assert_eq!(info.code, 503);
@@ -355,10 +412,9 @@ mod tests {
             }
             e => panic!("Unexpected error type: {:?}", e),
         };
-
-        get_changeset_mock.delete();
     }
 
+    /* // TODO: This should really be in the HTTP tests
     #[test]
     fn test_fetch_follows_redirects() {
         init();
@@ -400,5 +456,5 @@ mod tests {
 
         redirects_mock.delete();
         changeset_mock.delete();
-    }
+    }*/
 }

--- a/src/client/net/dummy_client.rs
+++ b/src/client/net/dummy_client.rs
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use super::{Requester, Response};
+
+/// A dummy HTTP client implementation that always errors.
+#[derive(Debug)]
+pub struct DummyClient;
+
+impl Requester for DummyClient {
+    fn get(&self, _url: url::Url) -> Result<Response, ()> {
+        Err(())
+    }
+}

--- a/src/client/net/mod.rs
+++ b/src/client/net/mod.rs
@@ -3,7 +3,6 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use std::collections::HashMap;
-use url::Url;
 
 mod dummy_client;
 #[cfg(test)]
@@ -16,6 +15,9 @@ pub(crate) use dummy_client::DummyClient;
 pub(crate) use test_client::{TestHttpClient, TestResponse};
 #[cfg(feature = "viaduct_client")]
 pub use viaduct_client::ViaductClient;
+
+// Re-exported so that consumers don't need depend on Url.
+pub use url::Url;
 
 /// A convenience type to represent raw HTTP headers.
 pub type Headers = HashMap<String, String>;

--- a/src/client/net/mod.rs
+++ b/src/client/net/mod.rs
@@ -1,0 +1,51 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::collections::HashMap;
+use url::Url;
+
+mod dummy_client;
+#[cfg(test)]
+mod test_client;
+#[cfg(feature = "viaduct_client")]
+mod viaduct_client;
+
+pub(crate) use dummy_client::DummyClient;
+#[cfg(test)]
+pub(crate) use test_client::{TestHttpClient, TestResponse};
+#[cfg(feature = "viaduct_client")]
+pub use viaduct_client::ViaductClient;
+
+/// A convenience type to represent raw HTTP headers.
+pub type Headers = HashMap<String, String>;
+
+/// A response coming from an HTTP endpoint.
+#[derive(Debug)]
+pub struct Response {
+    /// The HTTP status code of the response.
+    pub status: u16,
+
+    // The body of the response.
+    pub body: Vec<u8>,
+
+    // The headers of the response.
+    pub headers: Headers,
+}
+
+impl Response {
+    /// Whether or not the response code represents HTTP success.
+    pub fn is_success(&self) -> bool {
+        (200..=299).contains(&self.status)
+    }
+}
+
+/// A description of a component used to perform an HTTP request.
+pub trait Requester: std::fmt::Debug + Send + Sync {
+    /// Perform an GET request toward the needed resource.
+    ///
+    /// # Arguments
+    ///
+    /// * `url` - the URL path to perform the HTTP GET on.
+    fn get(&self, url: Url) -> Result<Response, ()>;
+}

--- a/src/client/net/mod.rs
+++ b/src/client/net/mod.rs
@@ -40,6 +40,16 @@ impl Response {
     pub fn is_success(&self) -> bool {
         (200..=299).contains(&self.status)
     }
+
+    /// Whether or not the response code represents HTTP client error.
+    pub fn is_client_error(&self) -> bool {
+        (400..=499).contains(&self.status)
+    }
+
+    /// Whether or not the response code represents HTTP server error.
+    pub fn is_server_error(&self) -> bool {
+        (500..=599).contains(&self.status)
+    }
 }
 
 /// A description of a component used to perform an HTTP request.

--- a/src/client/net/test_client.rs
+++ b/src/client/net/test_client.rs
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use super::{Headers, Requester, Response};
+
+#[cfg(test)]
+#[derive(Debug)]
+pub(crate) struct TestResponse {
+    pub request_url: String,
+    pub response_status: u16,
+    pub response_body: Vec<u8>,
+    pub response_headers: Headers,
+}
+
+/// A dummy HTTP client to use in tests
+#[cfg(test)]
+#[derive(Debug)]
+pub(crate) struct TestHttpClient {
+    request_must_fail: bool,
+    test_responses: Vec<TestResponse>,
+}
+
+#[cfg(test)]
+impl TestHttpClient {
+    pub fn new(request_must_fail: bool, test_responses: Vec<TestResponse>) -> TestHttpClient {
+        Self {
+            request_must_fail,
+            test_responses,
+        }
+    }
+}
+
+#[cfg(test)]
+impl Requester for TestHttpClient {
+    fn get(&self, url: url::Url) -> Result<Response, ()> {
+        // Let's fail if we are asked to.
+        if self.request_must_fail {
+            return Err(());
+        }
+
+        for r in &self.test_responses {
+            // Only respond to the specific URL if we're told to.
+            if url.to_string().eq(&r.request_url) {
+                return Ok(Response {
+                    status: r.response_status,
+                    body: r.response_body.clone(),
+                    headers: r.response_headers.clone(),
+                });
+            }
+        }
+
+        Ok(Response {
+            status: 404,
+            body: vec![],
+            headers: Headers::new(),
+        })
+    }
+}

--- a/src/client/net/test_client.rs
+++ b/src/client/net/test_client.rs
@@ -4,7 +4,6 @@
 
 use super::{Headers, Requester, Response};
 
-#[cfg(test)]
 #[derive(Debug)]
 pub(crate) struct TestResponse {
     pub request_url: String,
@@ -14,14 +13,12 @@ pub(crate) struct TestResponse {
 }
 
 /// A dummy HTTP client to use in tests
-#[cfg(test)]
 #[derive(Debug)]
 pub(crate) struct TestHttpClient {
     request_must_fail: bool,
     test_responses: Vec<TestResponse>,
 }
 
-#[cfg(test)]
 impl TestHttpClient {
     pub fn new(request_must_fail: bool, test_responses: Vec<TestResponse>) -> TestHttpClient {
         Self {
@@ -31,7 +28,6 @@ impl TestHttpClient {
     }
 }
 
-#[cfg(test)]
 impl Requester for TestHttpClient {
     fn get(&self, url: url::Url) -> Result<Response, ()> {
         // Let's fail if we are asked to.

--- a/src/client/net/test_client.rs
+++ b/src/client/net/test_client.rs
@@ -15,26 +15,17 @@ pub(crate) struct TestResponse {
 /// A dummy HTTP client to use in tests
 #[derive(Debug)]
 pub(crate) struct TestHttpClient {
-    request_must_fail: bool,
     test_responses: Vec<TestResponse>,
 }
 
 impl TestHttpClient {
-    pub fn new(request_must_fail: bool, test_responses: Vec<TestResponse>) -> TestHttpClient {
-        Self {
-            request_must_fail,
-            test_responses,
-        }
+    pub fn new(test_responses: Vec<TestResponse>) -> TestHttpClient {
+        Self { test_responses }
     }
 }
 
 impl Requester for TestHttpClient {
     fn get(&self, url: url::Url) -> Result<Response, ()> {
-        // Let's fail if we are asked to.
-        if self.request_must_fail {
-            return Err(());
-        }
-
         for r in &self.test_responses {
             // Only respond to the specific URL if we're told to.
             if url.to_string().eq(&r.request_url) {

--- a/src/client/net/viaduct_client.rs
+++ b/src/client/net/viaduct_client.rs
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use super::{Headers, Requester, Response};
+
+use viaduct::Request as ViaductRequest;
+
+/// An HTTP client that uses [Viaduct](https://github.com/mozilla/application-services/tree/main/components/viaduct).
+#[derive(Debug)]
+pub struct ViaductClient;
+
+impl Requester for ViaductClient {
+    fn get(&self, url: url::Url) -> Result<Response, ()> {
+        match ViaductRequest::get(url).send() {
+            Err(e) => {
+                log::error!(
+                    "ViaductClient - unable to submit GET request. {:?}",
+                    e.to_string()
+                );
+                Err(())
+            }
+            Ok(response) => {
+                let mut headers: Headers = Headers::new();
+                for h in response.headers {
+                    headers
+                        .entry(h.name().to_string())
+                        .or_insert(h.value().to_string());
+                }
+
+                return Ok(Response {
+                    status: response.status,
+                    body: response.body,
+                    headers,
+                });
+            }
+        }
+    }
+}

--- a/src/client/net/viaduct_client.rs
+++ b/src/client/net/viaduct_client.rs
@@ -25,14 +25,14 @@ impl Requester for ViaductClient {
                 for h in response.headers {
                     headers
                         .entry(h.name().to_string())
-                        .or_insert(h.value().to_string());
+                        .or_insert_with(|| h.value().to_string());
                 }
 
-                return Ok(Response {
+                Ok(Response {
                     status: response.status,
                     body: response.body,
                     headers,
-                });
+                })
             }
         }
     }

--- a/src/client/signatures.rs
+++ b/src/client/signatures.rs
@@ -125,7 +125,7 @@ pub trait Verification: Send {
         collection: &Collection,
         root_hash: &str,
     ) -> Result<(), SignatureError> {
-        let pem_bytes = self.fetch_certificate_chain(requester, &collection)?;
+        let pem_bytes = self.fetch_certificate_chain(requester, collection)?;
 
         let signature_bytes = collection.metadata["signature"]["signature"]
             .as_str()
@@ -334,7 +334,7 @@ mod tests {
             cid: "".to_string(),
             metadata: json!({
                 "signature": {
-                    "x5u": url.clone()
+                    "x5u": url.to_string()
                 }
             }),
             records: vec![],

--- a/src/client/signatures.rs
+++ b/src/client/signatures.rs
@@ -224,7 +224,6 @@ mod tests {
         expected_result: Result<(), SignatureError>,
     ) {
         let test_http_client: Box<dyn Requester + 'static> = Box::new(TestHttpClient::new(
-            false,
             vec![TestResponse {
                 request_url:
                     "https://example.com/chains/remote-settings.content-signature.mozilla.org-2020-09-04-17-16-15.chain"
@@ -302,10 +301,7 @@ mod tests {
         });
         let expectations: Vec<(&str, &str)> = vec![
             ("%^", "bad URL format: relative URL without a base"),
-            (
-                "http://localhost:9999/bad",
-                "HTTP backend issue",
-            ),
+            ("http://localhost:9999/bad", "HTTP backend issue"),
             (&mock_server_address, "/file.pem: HTTP 404"),
         ];
 
@@ -323,8 +319,11 @@ mod tests {
                 signer: "".to_string(),
             };
 
-            let viaduct_client: Box<dyn Requester + 'static> = Box::new(crate::client::net::ViaductClient);
-            let err = verifier.fetch_certificate_chain(&viaduct_client, &collection).unwrap_err();
+            let viaduct_client: Box<dyn Requester + 'static> =
+                Box::new(crate::client::net::ViaductClient);
+            let err = verifier
+                .fetch_certificate_chain(&viaduct_client, &collection)
+                .unwrap_err();
             assert!(err.to_string().contains(error), "{}", err.to_string());
         }
 
@@ -337,15 +336,7 @@ mod tests {
 
         let url = "https://example.com/file.pem";
 
-        let test_client: Box<dyn Requester + 'static> = Box::new(TestHttpClient::new(
-            false,
-            vec![TestResponse {
-                request_url: url.to_string(),
-                response_status: 404,
-                response_body: vec![],
-                response_headers: Headers::new(),
-            }],
-        ));
+        let test_client: Box<dyn Requester + 'static> = Box::new(TestHttpClient::new(vec![]));
 
         let collection = Collection {
             bid: "".to_string(),

--- a/src/client/signatures.rs
+++ b/src/client/signatures.rs
@@ -84,7 +84,7 @@ pub trait Verification: Send {
         debug!("Fetching certificate {}", x5u);
 
         let response = requester
-            .get(Url::parse(&x5u)?)
+            .get(Url::parse(x5u)?)
             .map_err(|_err| SignatureError::HTTPBackendError())?;
 
         if !response.is_success() {

--- a/src/client/signatures/dummy_verifier.rs
+++ b/src/client/signatures/dummy_verifier.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::{Collection, SignatureError, Verification};
+use crate::client::net::Requester;
 use log::debug;
 
 pub struct DummyVerifier {}
@@ -20,7 +21,12 @@ impl Verification for DummyVerifier {
         Ok(()) // unreachable.
     }
 
-    fn verify(&self, _collection: &Collection, _: &str) -> Result<(), SignatureError> {
+    fn verify(
+        &self,
+        _requester: &Box<dyn Requester + 'static>,
+        _collection: &Collection,
+        _: &str,
+    ) -> Result<(), SignatureError> {
         debug!("default verifier implementation");
         Ok(())
     }


### PR DESCRIPTION
The purpose of this PR is to decouple the HTTP client functionalities from the main remote-settings-client implementation. This is done by introducing a trait that describes a GET operation.

Users of remote-settings-client will need to provide an implementation using the trait when building the client (using viaduct or whatever else).

We could potentially offer feature-gated implementations for viaduct, or just leave it to the dummy one.

I'm planning on keeping using Viaduct in the rs-demo so that it would still work as an example.

@leplatrem what are your thoughts about this? It doesn't seem too much work to add this. Other than the big test refactoring, it feels fairly straightforward.

cc @mythmon 