### PR TITLE
Use a CI base image that includes clippy and cargo-hack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: rust:1
+      - image: mozilla/cidockerbases:rust-latest
     steps:
       - checkout
       - run:
@@ -65,6 +65,7 @@ jobs:
             rustup component add clippy
             cargo clippy --version
             cargo clippy --all-targets --all-features
+            cargo hack --feature-powerset clippy
       - run:
           name: rustfmt
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           command: cargo generate-lockfile
       - restore_cache:
           keys:
-            - v4-cargo-cache-{{ arch }}-{{ rustc --version }}-{{ checksum "Cargo.lock" }}
+            - v4-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
       - run:
           name: Build all targets
           command: cargo build --all --all-targets
@@ -54,7 +54,7 @@ jobs:
             - target/debug/build
             - target/debug/deps
             - libs/
-          key: v4-cargo-cache-{{ arch }}-{{ rustc --version }}-{{ checksum "Cargo.lock" }}
+          key: v4-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
       - run:
           name: Clippy
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           command: cargo generate-lockfile
       - restore_cache:
           keys:
-            - v4-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
+            - v4-cargo-cache-{{ arch }}-{{ rustc --version }}-{{ checksum "Cargo.lock" }}
       - run:
           name: Build all targets
           command: cargo build --all --all-targets
@@ -54,7 +54,7 @@ jobs:
             - target/debug/build
             - target/debug/deps
             - libs/
-          key: v4-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
+          key: v4-cargo-cache-{{ arch }}-{{ rustc --version }}-{{ checksum "Cargo.lock" }}
       - run:
           name: Clippy
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,13 +8,15 @@ jobs:
       - checkout
       - run:
           name: Version information
-          command: rustc --version; cargo --version; rustup --version
+          command: |
+            rustc --version; cargo --version; rustup --version;
+            export RUST_VERION=$(rustc --version)
       - run:
           name: Calculate dependencies
           command: cargo generate-lockfile
       - restore_cache:
           keys:
-            - v4-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
+            - v4-cargo-cache-{{ arch }}-{{ .Environment.RUST_VERSION }}-{{ checksum "Cargo.lock" }}
       - run:
           name: Build all targets
           command: cargo build --all --all-targets
@@ -54,7 +56,7 @@ jobs:
             - target/debug/build
             - target/debug/deps
             - libs/
-          key: v4-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
+          key: v4-cargo-cache-{{ arch }}-{{ .Environment.RUST_VERSION }}-{{ checksum "Cargo.lock" }}
       - run:
           name: Clippy
           command: |


### PR DESCRIPTION
CI didn't run on #155, so I missed that we didn't have Clippy installed in CI.