### PR TITLE
 Fix #146: add write methods

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,14 +90,42 @@ jobs:
             export NSS_STATIC=1
 
             cargo doc --all-features
+  demo:
+    machine:
+      image: ubuntu-2004:202111-02
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            curl https://sh.rustup.rs | sh -s -- --no-modify-path --default-toolchain stable -y;
+      - run:
+          name: Version information
+          command: |
+            source $HOME/.cargo/env
+            rustc --version; cargo --version; rustup --version;
+            docker --version; docker-compose --version;
+      - checkout
+      - run:
+          name: Run local Remote Settings
+          command: |
+            docker run --name rs.local \
+                       --detach \
+                       -e KINTO_INI=config/testing.ini \
+                       -e KINTO_SIGNER_RESOURCES="/buckets/main-workspace/collections/product-integrity -> /buckets/main-preview/collections/product-integrity -> /buckets/main/collections/product-integrity" \
+                       -p 8888:8888 \
+                       mozilla/remote-settings && \
+            curl --retry 10 --retry-delay 1 --retry-connrefused http://0.0.0.0:8888/v1/__heartbeat__
       - run:
           name: Run demo project
           command: |
+            source $HOME/.cargo/env
             pushd rs-client-demo/
             cargo run
             popd
+
 workflows:
   version: 2
   test:
     jobs:
       - test
+      - demo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 **Bug fixes**
 **New features**
+- Add support for write methods (#172)
+
 **Internal Changes**
 - Bump rc_crypto from v87.1.0 to v91.1.0 (#171, #185, #197)
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -355,6 +355,8 @@ pub struct Client {
     http_client: Box<dyn net::Requester + 'static>,
     #[builder(default = "None")]
     server_info: Option<Value>,
+    #[builder(default = "None")]
+    authorization: Option<String>,
 }
 
 impl Default for Client {
@@ -824,7 +826,7 @@ mod tests {
         assert!(client.sync_if_empty);
         assert!(client.trust_local);
         // And Debug format
-        assert_eq!(format!("{:?}", client), "Client { server_url: \"https://firefox.settings.services.mozilla.com/v1\", bucket_name: \"main\", collection_name: \"cid\", signer_name: \"remote-settings.content-signature.mozilla.org\", verifier: Box<dyn Verification>, storage: Box<dyn Storage>, sync_if_empty: true, trust_local: true, backoff_until: None, cert_root_hash: \"97:E8:BA:9C:F1:2F:B3:DE:53:CC:42:A4:E6:57:7E:D6:4D:F4:93:C2:47:B4:14:FE:A0:36:81:8D:38:23:56:0E\", http_client: DummyClient, server_info: None }");
+        assert_eq!(format!("{:?}", client), "Client { server_url: \"https://firefox.settings.services.mozilla.com/v1\", bucket_name: \"main\", collection_name: \"cid\", signer_name: \"remote-settings.content-signature.mozilla.org\", verifier: Box<dyn Verification>, storage: Box<dyn Storage>, sync_if_empty: true, trust_local: true, backoff_until: None, cert_root_hash: \"97:E8:BA:9C:F1:2F:B3:DE:53:CC:42:A4:E6:57:7E:D6:4D:F4:93:C2:47:B4:14:FE:A0:36:81:8D:38:23:56:0E\", http_client: DummyClient, server_info: None, authorization: None }");
     }
 
     #[tokio::test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -702,7 +702,7 @@ fn merge_changes(local_records: Vec<Record>, remote_changes: Vec<KintoObject>) -
 
 #[cfg(test)]
 mod tests {
-    use super::net::{Headers, Requester, TestHttpClient, TestResponse};
+    use super::net::{Headers, Method, Requester, TestHttpClient, TestResponse};
     use super::signatures::{SignatureError, Verification};
     use super::{
         Client, ClientError, Collection, DummyStorage, DummyVerifier, MemoryStorage, Record,
@@ -1450,6 +1450,7 @@ mod tests {
         let test_responses: Vec<_> = [777, 888]
             .iter()
             .map(|&expected| TestResponse {
+                request_method: Method::GET,
                 request_url: format!(
                     "{}/buckets/main/collections/nimbus/changeset?_expected={}",
                     fake_server, expected
@@ -1499,6 +1500,7 @@ mod tests {
         let test_responses = vec![
             // server metadata
             TestResponse {
+                request_method: Method::GET,
                 request_url: fake_server.to_string(),
                 response_status: 200,
                 response_body: json!({
@@ -1513,6 +1515,7 @@ mod tests {
 
             // list of changed collections
             TestResponse {
+                request_method: Method::GET,
                 request_url: format!(
                     "{}/buckets/monitor/collections/changes/changeset?_expected=0",
                     fake_server
@@ -1533,6 +1536,7 @@ mod tests {
 
             // changes for this collection
             TestResponse {
+                request_method: Method::GET,
                 request_url: format!(
                     "{}/buckets/main/collections/some-attachments/changeset?_expected=0",
                     fake_server
@@ -1562,6 +1566,7 @@ mod tests {
 
             // fake signature
             TestResponse {
+                request_method: Method::GET,
                 request_url: format!("{}/x5u", fake_server),
                 response_status: 200,
                 response_body: vec![],
@@ -1570,6 +1575,7 @@ mod tests {
 
             // The attachment
             TestResponse {
+                request_method: Method::GET,
                 request_url: format!(
                     "{}/attachments/1",
                     fake_server
@@ -1668,6 +1674,7 @@ mod tests {
         let test_responses = vec![
             // server metadata
             TestResponse {
+                request_method: Method::GET,
                 request_url: fake_server.to_string(),
                 response_status: 200,
                 response_body: json!({
@@ -1684,6 +1691,7 @@ mod tests {
             },
             // list of changed collections
             TestResponse {
+                request_method: Method::GET,
                 request_url: format!(
                     "{}/buckets/monitor/collections/changes/changeset?_expected=0",
                     fake_server
@@ -1706,6 +1714,7 @@ mod tests {
             },
             // changes for this collection
             TestResponse {
+                request_method: Method::GET,
                 request_url: format!(
                     "{}/buckets/main/collections/some-attachments/changeset?_expected=0",
                     fake_server
@@ -1756,6 +1765,7 @@ mod tests {
         let test_responses = vec![
             // server metadata
             TestResponse {
+                request_method: Method::GET,
                 request_url: fake_server.to_string(),
                 response_status: 200,
                 response_body: json!({
@@ -1770,6 +1780,7 @@ mod tests {
 
             // list of changed collections
             TestResponse {
+                request_method: Method::GET,
                 request_url: format!(
                     "{}/buckets/monitor/collections/changes/changeset?_expected=0",
                     fake_server
@@ -1790,6 +1801,7 @@ mod tests {
 
             // changes for this collection
             TestResponse {
+                request_method: Method::GET,
                 request_url: format!(
                     "{}/buckets/main/collections/some-attachments/changeset?_expected=0",
                     fake_server
@@ -1815,6 +1827,7 @@ mod tests {
 
             // The attachment
             TestResponse {
+                request_method: Method::GET,
                 request_url: format!(
                     "{}/attachments/1",
                     fake_server

--- a/src/client/net/dummy_client.rs
+++ b/src/client/net/dummy_client.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use super::{Requester, Response};
+use super::{Headers, Method, Requester, Response};
 
 use async_trait::async_trait;
 
@@ -13,6 +13,16 @@ pub struct DummyClient;
 #[async_trait]
 impl Requester for DummyClient {
     async fn get(&self, _url: url::Url) -> Result<Response, ()> {
+        Err(())
+    }
+
+    async fn request_json(
+        &self,
+        _method: Method,
+        _url: url::Url,
+        _data: Vec<u8>,
+        _headers: Headers,
+    ) -> Result<Response, ()> {
         Err(())
     }
 }

--- a/src/client/net/mod.rs
+++ b/src/client/net/mod.rs
@@ -24,6 +24,16 @@ pub use url::Url;
 /// A convenience type to represent raw HTTP headers.
 pub type Headers = HashMap<String, String>;
 
+/// HTTP method.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Method {
+    GET,
+    PATCH,
+    POST,
+    PUT,
+    DELETE,
+}
+
 /// A response coming from an HTTP endpoint.
 #[derive(Debug)]
 pub struct Response {
@@ -63,4 +73,20 @@ pub trait Requester: std::fmt::Debug + Send + Sync {
     ///
     /// * `url` - the URL path to perform the HTTP GET on.
     async fn get(&self, url: Url) -> Result<Response, ()>;
+
+    /// Perform a JSON request toward the needed resource.
+    ///
+    /// # Arguments
+    ///
+    /// * `method` - the HTTP method.
+    /// * `url` - the URL path to perform the request.
+    /// * `data` - the body content to send.
+    /// * `headers` - the headers to send.
+    async fn request_json(
+        &self,
+        method: Method,
+        url: Url,
+        data: Vec<u8>,
+        headers: Headers,
+    ) -> Result<Response, ()>;
 }

--- a/src/client/net/test_client.rs
+++ b/src/client/net/test_client.rs
@@ -58,10 +58,12 @@ impl Requester for TestHttpClient {
         for r in &self.test_responses {
             // Only respond to the specific URL if we're told to.
             if r.request_method == method && url.to_string().eq(&r.request_url) {
+                let mut headers = r.response_headers.clone();
+                headers.insert("Content-Type".into(), "application/json".into());
                 return Ok(Response {
                     status: r.response_status,
                     body: r.response_body.clone(),
-                    headers: r.response_headers.clone(),
+                    headers,
                 });
             }
         }

--- a/src/client/net/test_client.rs
+++ b/src/client/net/test_client.rs
@@ -2,12 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use super::{Headers, Requester, Response};
+use super::{Headers, Method, Requester, Response};
 
 use async_trait::async_trait;
 
 #[derive(Debug)]
 pub(crate) struct TestResponse {
+    pub request_method: Method,
     pub request_url: String,
     pub response_status: u16,
     pub response_body: Vec<u8>,
@@ -31,7 +32,32 @@ impl Requester for TestHttpClient {
     async fn get(&self, url: url::Url) -> Result<Response, ()> {
         for r in &self.test_responses {
             // Only respond to the specific URL if we're told to.
-            if url.to_string().eq(&r.request_url) {
+            if r.request_method == Method::GET && url.to_string().eq(&r.request_url) {
+                return Ok(Response {
+                    status: r.response_status,
+                    body: r.response_body.clone(),
+                    headers: r.response_headers.clone(),
+                });
+            }
+        }
+
+        Ok(Response {
+            status: 404,
+            body: vec![],
+            headers: Headers::new(),
+        })
+    }
+
+    async fn request_json(
+        &self,
+        method: Method,
+        url: url::Url,
+        _data: Vec<u8>,
+        _: Headers,
+    ) -> Result<Response, ()> {
+        for r in &self.test_responses {
+            // Only respond to the specific URL if we're told to.
+            if r.request_method == method && url.to_string().eq(&r.request_url) {
                 return Ok(Response {
                     status: r.response_status,
                     body: r.response_body.clone(),

--- a/src/client/net/viaduct_client.rs
+++ b/src/client/net/viaduct_client.rs
@@ -28,7 +28,7 @@ impl Requester for ViaductClient {
         let mut request = match method {
             Method::DELETE => ViaductRequest::delete(url),
             Method::GET => ViaductRequest::get(url),
-            Method::PATCH => ViaductRequest::put(url), // XXX patch()! https://github.com/mozilla/application-services/pull/4751
+            Method::PATCH => ViaductRequest::patch(url),
             Method::PUT => ViaductRequest::put(url),
             Method::POST => ViaductRequest::post(url),
         }


### PR DESCRIPTION
This PR adds ability to store and delete records, as well as request, approve, reject, or rollback changes.

We intentionally didn't add creation of buckets, collections, and groups, as these operations are not part of user workflows on Remote Settings servers.

(recreated from #172)