### PR TITLE
Fixes #418: Get rid of async/await and switch to sync code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,16 +10,13 @@ readme = "README.md"
 default = []
 ring_verifier = ["oid-registry", "ring"]
 rc_crypto_verifier = ["rc_crypto"]
-# Using viaduct requires using tokio as well because we need to use the
-# `spawn_blocking` API.
-viaduct_client = ["viaduct", "tokio"]
+viaduct_client = ["viaduct"]
 
 [dev-dependencies]
 env_logger = "0.11.2"
 httpmock = "0.7.0"
 viaduct-reqwest = { git = "https://github.com/mozilla/application-services", rev = "v128.0"}
 mock_instant = "0.5.1"
-tokio = { version = "1.8.2", features = ["macros"] }
 # The following line is a workaround suggested on the rust-lang/cargo issue 2911
 # https://github.com/rust-lang/cargo/issues/2911#issuecomment-749580481 to make
 # it possible to enable features for tests. We need to enable the "viaduct_client"
@@ -29,7 +26,6 @@ remote-settings-client = { path = ".", features = ["viaduct_client"] }
 
 [dependencies]
 anyhow = "1"
-async-trait = "0.1.51"
 base64 = "0.22.0"
 canonical_json = "0.5"
 hex = "0.4"
@@ -41,7 +37,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 derive_builder = "0.20"
 thiserror = "1.0"
-tokio = { version = "1.8.2", features = ["rt"], optional = true }
 
 # ring_verifier
 ring = { version = "0.17", optional = true }

--- a/README.md
+++ b/README.md
@@ -13,11 +13,9 @@ Available features:
 <!-- - Cross-Platform
 - Robust -->
 
-Consumers can define their own HTTP implementation by implementing the `net::Requester` trait.
-This library provides an implementation of the the `net::ViaductClient` HTTP requester based on on Mozilla's [viaduct](https://github.com/mozilla/application-services/tree/v128.0/components/viaduct) for its pluggable HTTP backend (eg. `reqwest` or `FFI` on Android).
+Relies on Mozilla's [viaduct](https://github.com/mozilla/application-services/tree/v75.0.0/components/viaduct) for its pluggable HTTP backend (eg. `reqwest` or `FFI` on Android).
 
 See also the `Storage` and `Verification` traits to extend or customize the client behaviour.
-
 
 ## Quick start
 
@@ -25,25 +23,26 @@ See also the `Storage` and `Verification` traits to extend or customize the clie
 
 ```toml
 [dependencies]
-remote-settings-client = { version = "0.1", features = ["ring_verifier", "viaduct_client"] }
-tokio = { version = "1.8.2", features = ["macros"] }
+remote-settings-client = { version = "0.1", features = ["ring_verifier"] }
+viaduct = { git = "https://github.com/mozilla/application-services", rev = "v75.2.0"}
+viaduct-reqwest = { git = "https://github.com/mozilla/application-services", rev = "v75.2.0"}
 ```
 
 Minimal example:
 
 ```rust
-use remote_settings_client::{Client, client::net::ViaductClient};
+use remote_settings_client::Client;
+pub use viaduct::set_backend;
+pub use viaduct_reqwest::ReqwestBackend;
 
-#[tokio::main]
-async fn main() {
-  viaduct::set_backend(&viaduct_reqwest::ReqwestBackend).unwrap();
+fn main() {
+  set_backend(&ReqwestBackend).unwrap();
 
   let client = Client::builder()
     .collection_name("search-config")
-    .http_client(Box::new(ViaductClient))
     .build();
 
-  match client.get().await {
+  match client.get() {
     Ok(records) => println!("{:?}", records),
     Err(error) => println!("Error fetching/verifying records: {:?}", error),
   };

--- a/rs-client-demo/Cargo.toml
+++ b/rs-client-demo/Cargo.toml
@@ -10,7 +10,6 @@ remote-settings-client = {path = "../", features = ["ring_verifier", "viaduct_cl
 log = "0.4.0"
 env_logger = "0.7.1"
 serde_json = "1.0"
-tokio = { version = "1.8.2", features = ["macros", "rt"] }
 # Specifying viaduct, viaduct-reqwest dependency from git repo since viaduct, viaduct-reqwest are not published yet to crates.io
 viaduct = { git = "https://github.com/mozilla/application-services", rev = "v128.0"}
 viaduct-reqwest = { git = "https://github.com/mozilla/application-services", rev = "v128.0"}

--- a/src/client.rs
+++ b/src/client.rs
@@ -512,7 +512,7 @@ impl Client {
             None => {
                 debug!("Obtain current timestamp.");
                 get_latest_change_timestamp(
-                    &self.http_client,
+                    self.http_client.as_ref(),
                     &self.server_url,
                     &self.bucket_name,
                     &self.collection_name,
@@ -540,7 +540,7 @@ impl Client {
         };
 
         let changeset = get_changeset(
-            &self.http_client,
+            self.http_client.as_ref(),
             &self.server_url,
             &self.bucket_name,
             &self.collection_name,

--- a/src/client.rs
+++ b/src/client.rs
@@ -72,8 +72,9 @@ pub struct Record {
     attachment: Attachment,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq)]
 pub enum Attachment {
+    #[default]
     Pending,
     None,
     Some(AttachmentMetadata),
@@ -86,12 +87,6 @@ pub struct AttachmentMetadata {
     pub filename: String,
     pub location: String,
     pub mimetype: String,
-}
-
-impl Default for Attachment {
-    fn default() -> Self {
-        Attachment::Pending
-    }
 }
 
 impl<'a> From<&'a Attachment> for Option<&'a AttachmentMetadata> {
@@ -829,7 +824,7 @@ fn merge_changes(local_records: Vec<Record>, remote_changes: Vec<KintoObject>) -
         }
     }
 
-    local_by_id.into_iter().map(|(_, v)| v).collect()
+    local_by_id.into_values().collect()
 }
 
 #[cfg(test)]
@@ -997,7 +992,7 @@ mod tests {
         });
 
         let mut client = Client::builder()
-            .server_url(&mock_server.url(""))
+            .server_url(mock_server.url(""))
             .http_client(Box::new(ViaductClient))
             .collection_name("top-sites")
             .storage(Box::new(DummyStorage {}))
@@ -1062,7 +1057,7 @@ mod tests {
         });
 
         let mut client = Client::builder()
-            .server_url(&mock_server.url(""))
+            .server_url(mock_server.url(""))
             .http_client(Box::new(ViaductClient))
             .collection_name("pocket")
             .storage(Box::new(MemoryStorage::new()))

--- a/src/client/kinto_http.rs
+++ b/src/client/kinto_http.rs
@@ -76,8 +76,8 @@ impl std::fmt::Display for ErrorResponse {
     }
 }
 
-pub async fn get_latest_change_timestamp(
-    requester: &'_ (dyn Requester + 'static),
+pub fn get_latest_change_timestamp(
+    requester: &Box<dyn Requester + 'static>,
     server: &str,
     bid: &str,
     cid: &str,
@@ -85,7 +85,7 @@ pub async fn get_latest_change_timestamp(
     // When we fetch the monitor/changes endpoint manually (ie. not from a push notification)
     // we cannot know the current timestamp, and use 0 arbitrarily.
     let expected = 0;
-    let response = get_changeset(requester, server, "monitor", "changes", expected, None).await?;
+    let response = get_changeset(requester, server, "monitor", "changes", expected, None)?;
     let change = response
         .changes
         .iter()
@@ -105,8 +105,8 @@ pub async fn get_latest_change_timestamp(
 }
 
 /// Fetches the collection content from the server.
-pub async fn get_changeset(
-    requester: &'_ (dyn Requester + 'static),
+pub fn get_changeset(
+    requester: &Box<dyn Requester + 'static>,
     server: &str,
     bid: &str,
     cid: &str,
@@ -118,7 +118,7 @@ pub async fn get_changeset(
         "{}/buckets/{}/collections/{}/changeset?_expected={}{}",
         server, bid, cid, expected, since_param
     );
-    let response = _request_resource(requester, None, Method::GET, url, vec![]).await?;
+    let response = _request_resource(requester.as_ref(), None, Method::GET, url, vec![])?;
     let mut changeset: ChangesetResponse = serde_json::from_slice(&response.body)?;
 
     // Check if server is indicating to clients to back-off.
@@ -127,7 +127,7 @@ pub async fn get_changeset(
     Ok(changeset)
 }
 
-pub async fn put_record<T>(
+pub fn put_record<T>(
     requester: &'_ (dyn Requester + 'static),
     server: &str,
     authorization: Option<String>,
@@ -156,13 +156,12 @@ where
         Method::PUT,
         record_url,
         json_bytes,
-    )
-    .await?;
+    )?;
     let kr: KintoResponse<KintoObject> = serde_json::from_slice(&response.body)?;
     Ok(kr.data.into())
 }
 
-pub async fn delete_record<T>(
+pub fn delete_record<T>(
     requester: &'_ (dyn Requester + 'static),
     server: &str,
     authorization: Option<String>,
@@ -179,13 +178,12 @@ where
         cid,
         rid,
     );
-    let response =
-        _request_resource(requester, authorization, Method::DELETE, record_url, vec![]).await?;
+    let response = _request_resource(requester, authorization, Method::DELETE, record_url, vec![])?;
     let kr: KintoResponse<KintoObject> = serde_json::from_slice(&response.body)?;
     Ok(kr.data.into())
 }
 
-pub async fn patch_collection<T>(
+pub fn patch_collection<T>(
     requester: &'_ (dyn Requester + 'static),
     server: &str,
     authorization: Option<String>,
@@ -208,8 +206,7 @@ where
         Method::PATCH,
         collection_url,
         json_bytes,
-    )
-    .await?;
+    )?;
     let kr: KintoResponse<KintoObject> = serde_json::from_slice(&response.body)?;
     Ok(kr.data.into())
 }
@@ -233,7 +230,7 @@ fn _workspace_url(server: &str, bid: &str) -> String {
     )
 }
 
-async fn _request_resource(
+fn _request_resource(
     requester: &'_ (dyn Requester + 'static),
     authorization: Option<String>,
     method: Method,
@@ -254,7 +251,6 @@ async fn _request_resource(
     info!("{:?} {}...", method, url);
     let response = requester
         .request_json(method, Url::parse(&url)?, data, headers)
-        .await
         .map_err(|_err| KintoError::HTTPBackendError())?;
 
     if !response.is_success() {
@@ -313,8 +309,8 @@ mod tests {
         let _ = env_logger::builder().is_test(true).try_init();
     }
 
-    #[tokio::test]
-    async fn test_fetch() {
+    #[test]
+    fn test_fetch() {
         init();
 
         let test_client: Box<dyn Requester + 'static> =
@@ -343,41 +339,35 @@ mod tests {
             }]));
 
         let res = get_latest_change_timestamp(
-            test_client.as_ref(),
+            &test_client,
             "https://example.com/v1",
             "main",
             "url-classifier-skip-urls",
         )
-        .await
         .unwrap();
 
         assert_eq!(res, 9173);
     }
 
-    #[tokio::test]
-    async fn test_bad_url() {
+    #[test]
+    fn test_bad_url() {
         init();
 
         let _ = viaduct::set_backend(&viaduct_reqwest::ReqwestBackend);
         let viaduct_client: Box<dyn Requester + 'static> =
             Box::new(crate::client::net::ViaductClient);
 
-        let err = get_latest_change_timestamp(
-            viaduct_client.as_ref(),
-            "%^",
-            "main",
-            "url-classifier-skip-urls",
-        )
-        .await
-        .unwrap_err();
+        let err =
+            get_latest_change_timestamp(&viaduct_client, "%^", "main", "url-classifier-skip-urls")
+                .unwrap_err();
         assert_eq!(
             err.to_string(),
             "bad URL format: relative URL without a base"
         )
     }
 
-    #[tokio::test]
-    async fn test_bad_json() {
+    #[test]
+    fn test_bad_json() {
         init();
 
         let test_client: Box<dyn Requester + 'static> =
@@ -396,18 +386,17 @@ mod tests {
             }]));
 
         let err = get_latest_change_timestamp(
-            test_client.as_ref(),
+            &test_client,
             "https://example.com",
             "main",
             "url-classifier-skip-urls",
         )
-        .await
         .unwrap_err();
         assert_eq!(err.to_string(), "changeset content could not be parsed: control character (\\u0000-\\u001F) found while parsing a string at line 3 column 0");
     }
 
-    #[tokio::test]
-    async fn test_bad_timestamp() {
+    #[test]
+    fn test_bad_timestamp() {
         init();
 
         let test_client: Box<dyn Requester + 'static> =
@@ -436,12 +425,11 @@ mod tests {
             }]));
 
         let err = get_latest_change_timestamp(
-            test_client.as_ref(),
+            &test_client,
             "https://example.com/v1",
             "main",
             "url-classifier-skip-urls",
         )
-        .await
         .unwrap_err();
 
         match err {
@@ -455,8 +443,8 @@ mod tests {
         };
     }
 
-    #[tokio::test]
-    async fn test_client_error_response() {
+    #[test]
+    fn test_client_error_response() {
         init();
 
         let test_client: Box<dyn Requester + 'static> =
@@ -482,14 +470,13 @@ mod tests {
             }]));
 
         let err = get_changeset(
-            test_client.as_ref(),
+            &test_client,
             "https://example.com/v1",
             "main",
             "cfr",
             451,
             None,
         )
-        .await
         .unwrap_err();
 
         match err {
@@ -505,8 +492,8 @@ mod tests {
         };
     }
 
-    #[tokio::test]
-    async fn test_server_error_response() {
+    #[test]
+    fn test_server_error_response() {
         init();
 
         let mut response_headers = Headers::new();
@@ -531,14 +518,13 @@ mod tests {
             }]));
 
         let err = get_changeset(
-            test_client.as_ref(),
+            &test_client,
             "https://example.com/v1",
             "main",
             "cfr",
             42,
             None,
         )
-        .await
         .unwrap_err();
 
         match err {
@@ -558,8 +544,8 @@ mod tests {
         };
     }
 
-    #[tokio::test]
-    async fn test_fetch_follows_redirects() {
+    #[test]
+    fn test_fetch_follows_redirects() {
         init();
 
         let mock_server = MockServer::start();
@@ -593,14 +579,9 @@ mod tests {
         let _ = viaduct::set_backend(&viaduct_reqwest::ReqwestBackend);
         let viaduct_client: Box<dyn Requester + 'static> =
             Box::new(crate::client::net::ViaductClient);
-        let res = get_latest_change_timestamp(
-            viaduct_client.as_ref(),
-            &mock_server.url(""),
-            "main",
-            "crlite",
-        )
-        .await
-        .unwrap();
+        let res =
+            get_latest_change_timestamp(&viaduct_client, &mock_server.url(""), "main", "crlite")
+                .unwrap();
 
         assert_eq!(res, 5678);
 
@@ -611,8 +592,8 @@ mod tests {
         changeset_mock.delete();
     }
 
-    #[tokio::test]
-    async fn test_put_record() {
+    #[test]
+    fn test_put_record() {
         init();
 
         let mock_server = MockServer::start();
@@ -648,7 +629,6 @@ mod tests {
                 "field": "value"
             }),
         )
-        .await
         .unwrap();
 
         put_record_mock.assert();
@@ -658,8 +638,8 @@ mod tests {
         assert_eq!(res["field"], "value");
     }
 
-    #[tokio::test]
-    async fn test_delete_record() {
+    #[test]
+    fn test_delete_record() {
         init();
 
         let mock_server = MockServer::start();
@@ -691,7 +671,6 @@ mod tests {
             "cid",
             "xyz",
         )
-        .await
         .unwrap();
 
         delete_record_mock.assert();
@@ -701,8 +680,8 @@ mod tests {
         assert_eq!(res["deleted"], true);
     }
 
-    #[tokio::test]
-    async fn test_patch_collection() {
+    #[test]
+    fn test_patch_collection() {
         init();
 
         let mock_server = MockServer::start();
@@ -737,7 +716,6 @@ mod tests {
                 "status": "to-sign"
             }),
         )
-        .await
         .unwrap();
 
         patch_collection_mock.assert();

--- a/src/client/net/dummy_client.rs
+++ b/src/client/net/dummy_client.rs
@@ -4,19 +4,16 @@
 
 use super::{Headers, Method, Requester, Response};
 
-use async_trait::async_trait;
-
 /// A dummy HTTP client implementation that always errors.
 #[derive(Debug)]
 pub struct DummyClient;
 
-#[async_trait]
 impl Requester for DummyClient {
-    async fn get(&self, _url: url::Url) -> Result<Response, ()> {
+    fn get(&self, _url: url::Url) -> Result<Response, ()> {
         Err(())
     }
 
-    async fn request_json(
+    fn request_json(
         &self,
         _method: Method,
         _url: url::Url,

--- a/src/client/net/mod.rs
+++ b/src/client/net/mod.rs
@@ -4,8 +4,6 @@
 
 use std::collections::HashMap;
 
-use async_trait::async_trait;
-
 mod dummy_client;
 #[cfg(test)]
 mod test_client;
@@ -65,14 +63,13 @@ impl Response {
 }
 
 /// A description of a component used to perform an HTTP request.
-#[async_trait]
 pub trait Requester: std::fmt::Debug + Send + Sync {
     /// Perform an GET request toward the needed resource.
     ///
     /// # Arguments
     ///
     /// * `url` - the URL path to perform the HTTP GET on.
-    async fn get(&self, url: Url) -> Result<Response, ()>;
+    fn get(&self, url: Url) -> Result<Response, ()>;
 
     /// Perform a JSON request toward the needed resource.
     ///
@@ -82,7 +79,7 @@ pub trait Requester: std::fmt::Debug + Send + Sync {
     /// * `url` - the URL path to perform the request.
     /// * `data` - the body content to send.
     /// * `headers` - the headers to send.
-    async fn request_json(
+    fn request_json(
         &self,
         method: Method,
         url: Url,

--- a/src/client/net/test_client.rs
+++ b/src/client/net/test_client.rs
@@ -4,8 +4,6 @@
 
 use super::{Headers, Method, Requester, Response};
 
-use async_trait::async_trait;
-
 #[derive(Debug)]
 pub(crate) struct TestResponse {
     pub request_method: Method,
@@ -27,9 +25,8 @@ impl TestHttpClient {
     }
 }
 
-#[async_trait]
 impl Requester for TestHttpClient {
-    async fn get(&self, url: url::Url) -> Result<Response, ()> {
+    fn get(&self, url: url::Url) -> Result<Response, ()> {
         for r in &self.test_responses {
             // Only respond to the specific URL if we're told to.
             if r.request_method == Method::GET && url.to_string().eq(&r.request_url) {
@@ -48,7 +45,7 @@ impl Requester for TestHttpClient {
         })
     }
 
-    async fn request_json(
+    fn request_json(
         &self,
         method: Method,
         url: url::Url,

--- a/src/client/signatures/dummy_verifier.rs
+++ b/src/client/signatures/dummy_verifier.rs
@@ -4,12 +4,10 @@
 
 use super::{Collection, SignatureError, Verification};
 use crate::client::net::Requester;
-use async_trait::async_trait;
 use log::debug;
 
 pub struct DummyVerifier {}
 
-#[async_trait]
 impl Verification for DummyVerifier {
     fn verify_nist384p_chain(
         &self,
@@ -23,7 +21,7 @@ impl Verification for DummyVerifier {
         Ok(()) // unreachable.
     }
 
-    async fn verify(
+    fn verify(
         &self,
         _requester: &'_ (dyn Requester + 'static),
         _collection: &Collection,

--- a/src/client/signatures/rc_crypto_verifier.rs
+++ b/src/client/signatures/rc_crypto_verifier.rs
@@ -3,14 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::{SignatureError, Verification};
-use async_trait::async_trait;
 use rc_crypto::{contentsignature, digest, ErrorKind as RcErrorKind};
 
 pub struct RcCryptoVerifier {}
 
 impl RcCryptoVerifier {}
 
-#[async_trait]
 impl Verification for RcCryptoVerifier {
     fn verify_nist384p_chain(
         &self,

--- a/src/client/signatures/ring_verifier.rs
+++ b/src/client/signatures/ring_verifier.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::{x509, SignatureError, Verification};
-use async_trait::async_trait;
 use base64::{engine::general_purpose::URL_SAFE, Engine as _};
 use hex;
 use ring::digest::{Context, SHA256};
@@ -14,7 +13,6 @@ pub struct RingVerifier {}
 
 impl RingVerifier {}
 
-#[async_trait]
 impl Verification for RingVerifier {
     fn verify_nist384p_chain(
         &self,

--- a/src/client/signatures/ring_verifier.rs
+++ b/src/client/signatures/ring_verifier.rs
@@ -41,7 +41,7 @@ impl Verification for RingVerifier {
         };
 
         // 2. Verify that root hash matches the SHA256 fingerprint of the root certificate (DER content)
-        let root_hash_bytes = hex::decode(&root_hash.replace(':', ""))
+        let root_hash_bytes = hex::decode(root_hash.replace(':', ""))
             .map_err(|err| SignatureError::RootHashFormatError(err.to_string()))?;
 
         let root_pem = pems.first().unwrap();
@@ -94,7 +94,7 @@ impl Verification for RingVerifier {
                 let public_key =
                     signature::UnparsedPublicKey::new(verification_alg, &parent_pk_bytes);
                 public_key
-                    .verify(child_der_bytes, &child_sig_bytes)
+                    .verify(child_der_bytes, child_sig_bytes)
                     .or(Err(SignatureError::CertificateTrustError))?;
             }
         }
@@ -122,7 +122,7 @@ impl Verification for RingVerifier {
         let signature_alg = &signature::ECDSA_P384_SHA384_FIXED;
         let public_key = signature::UnparsedPublicKey::new(signature_alg, &public_key_bytes);
 
-        let decoded_signature = match URL_SAFE.decode(&signature) {
+        let decoded_signature = match URL_SAFE.decode(signature) {
             Ok(s) => s,
             Err(err) => return Err(SignatureError::BadSignatureContent(err.to_string())),
         };

--- a/src/client/storage/file_storage.rs
+++ b/src/client/storage/file_storage.rs
@@ -110,7 +110,7 @@ mod tests {
     }
 
     fn cleanup(file_path: &str) {
-        if remove_file(&file_path).is_err() {
+        if remove_file(file_path).is_err() {
             error!("Error removing file : {}", file_path);
         };
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,26 +13,23 @@
 //!   use viaduct::set_backend;
 //!   use viaduct_reqwest::ReqwestBackend;
 //!
-//! # #[tokio::main]
-//! # async fn main() {
 //!   set_backend(&ReqwestBackend).unwrap();
 //!
 //!   let mut client = Client::builder()
-//!     .bucket_name("main-preview")
 //!     .http_client(Box::new(ViaductClient))
+//!     .bucket_name("main-preview")
 //!     .collection_name("search-config")
 //!     .verifier(Box::new(RingVerifier {}))
 //!     .build()
 //!     .unwrap();
 //!
-//!   client.sync(None).await.unwrap();
+//!   client.sync(None).unwrap();
 //!
-//!   match client.get().await {
+//!   match client.get() {
 //!     Ok(records) => println!("{:?}", records),
 //!     Err(error) => println!("Error fetching/verifying records: {:?}", error),
 //!   };
 //! # }
-//! }
 //! ```
 //!
 //! See [`Client`] for more infos.


### PR DESCRIPTION
Fixes #418

Since there is no consumer for the async/await code anymore, we can stick to the sync API (as the rest of application-services)

This reverts commit 02a00fbdd89ea03c88ff39380ca61fa88faac05a, reversing changes made to e3141764ef960e9b9f47426f12557d9f89254b06.


@bendk ?